### PR TITLE
修复上传文件必现的 SimpleDirectoryReader 报错

### DIFF
--- a/backend/app/utils/llama.py
+++ b/backend/app/utils/llama.py
@@ -39,7 +39,7 @@ def get_nodes_from_file(file_path):
     """
     # 加载文本分词器
     parser = SimpleNodeParser.from_defaults()
-    documents = SimpleDirectoryReader(file_path, filename_as_id=True).load_data()
+    documents = SimpleDirectoryReader(input_files=[file_path], filename_as_id=True).load_data()
     for doc in documents:
         doc.id_ = extract_content_after_backslash(doc.id_)
     return parser.get_nodes_from_documents(documents)

--- a/tests/test_get_nodes_from_file.py
+++ b/tests/test_get_nodes_from_file.py
@@ -1,0 +1,30 @@
+import os
+import tempfile
+import unittest
+
+import tests._pathsetup  # noqa: F401  (adds backend/app to sys.path)
+
+import utils.llama as llama_utils
+
+
+class GetNodesFromFileTest(unittest.TestCase):
+    def test_loads_nodes_from_a_single_file_path(self):
+        """get_nodes_from_file is called with a path to one uploaded file (e.g. from
+        insert_into_index), not a directory. SimpleDirectoryReader's first
+        positional/keyword arg is input_dir though -- passing a file path there
+        makes it try to list a directory that doesn't exist and fail with
+        'Directory <file path> does not exist.', exactly as reported against
+        /index/{name}/uploadFile."""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            file_path = os.path.join(tmp_dir, 'note.txt')
+            with open(file_path, 'w', encoding='utf-8') as f:
+                f.write("图书馆每天早上8点到晚上10点开放。")
+
+            nodes = llama_utils.get_nodes_from_file(file_path)
+
+        self.assertTrue(nodes)
+        self.assertIn("图书馆", nodes[0].get_content())
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- `get_nodes_from_file()` 把上传文件的路径当成 `input_dir` 传给 `SimpleDirectoryReader`，而它的第一个参数是目录，不是文件——导致 `/index/{name}/uploadFile`、`uploadFiles` 无论传什么文件都会报 `Directory <file path> does not exist.`
- 改成 `SimpleDirectoryReader(input_files=[file_path], ...)`

## Test plan
- [x] 新增单测复现了一模一样的报错信息，再验证修复后通过
- [x] 用你实际报错时的命令原样复现并验证修复：
  ```
  curl -X POST 'http://127.0.0.1:8000/index/test/uploadFile' -F 'file=@转专业政策.txt;type=text/plain'
  ```
  上传成功、`/index/test/info` 能看到文档、针对文档内容真实提问也拿到了正确详细的回答

🤖 Generated with [Claude Code](https://claude.com/claude-code)