### PR TITLE
修复 extract_content_after_backslash 不处理正斜杠路径

### DIFF
--- a/backend/app/utils/llama.py
+++ b/backend/app/utils/llama.py
@@ -47,12 +47,11 @@ def get_nodes_from_file(file_path):
 
 def extract_content_after_backslash(string):
     """
-    去除文件名中的路径
+    去除文件名中的路径（同时兼容 Windows 反斜杠路径和 POSIX 正斜杠路径）
     :param string:
     :return:
     """
-    parts = string.split('\\')
-    return parts[-1]
+    return string.replace('\\', '/').rsplit('/', 1)[-1]
 
 
 def formatted_pairs(qa_data_list):

--- a/tests/test_extract_content_after_backslash.py
+++ b/tests/test_extract_content_after_backslash.py
@@ -1,0 +1,34 @@
+import unittest
+
+import tests._pathsetup  # noqa: F401  (adds backend/app to sys.path)
+
+import utils.llama as llama_utils
+
+
+class ExtractContentAfterBackslashTest(unittest.TestCase):
+    def test_strips_windows_style_backslash_paths(self):
+        """Existing case: some browsers report file.filename as a full Windows
+        path like C:\\fakepath\\file.txt."""
+        self.assertEqual(
+            llama_utils.extract_content_after_backslash("C:\\fakepath\\转专业政策.txt"),
+            "转专业政策.txt",
+        )
+
+    def test_strips_posix_style_forward_slash_paths(self):
+        """get_nodes_from_file assigns doc.id_ to the absolute file path on disk,
+        which on Linux uses forward slashes -- the old implementation only split
+        on backslash, so on Linux doc_id ended up as the full absolute path
+        instead of just the filename."""
+        self.assertEqual(
+            llama_utils.extract_content_after_backslash(
+                "/home/cy/github/chuanyue98/CUITCCA/backend/app/../../data/temp/转专业政策.txt"
+            ),
+            "转专业政策.txt",
+        )
+
+    def test_plain_filename_is_unchanged(self):
+        self.assertEqual(llama_utils.extract_content_after_backslash("note.txt"), "note.txt")
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
PR #7 合并时只带上了第一个 commit（SimpleDirectoryReader 修复），第二个 commit（`extract_content_after_backslash` 修复）当时还没来得及并进去，单独开一个 PR 补上。

- `extract_content_after_backslash` 之前只按反斜杠切分，Linux 下 `doc.id_`（`SimpleDirectoryReader` 赋值为磁盘上的绝对路径）用的是正斜杠，导致 `doc_id` 一直是完整路径而不是文件名
- 改成先把反斜杠统一成正斜杠，再取最后一段

## Test plan
- [x] 单测复现了真实路径场景，验证修复前后行为
- [x] 重启服务实测：新上传文件后 `doc_id` 是干净文件名（如 `挂失流程.txt`），不再是全路径

🤖 Generated with [Claude Code](https://claude.com/claude-code)